### PR TITLE
Bugfix unwanted propagation of configuration settings to active modules

### DIFF
--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/config/bean/ConfigDomainModelBean.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/config/bean/ConfigDomainModelBean.java
@@ -278,6 +278,7 @@ public class ConfigDomainModelBean implements ConfigDomainModel {
         // Create new setting
         Setting entity = mapper.toEntity(setting, username);
         Setting createdSetting = dao.createSetting(entity);
+        createdSetting.setModule(module);
         module.getSettings().add(createdSetting);
         return mapper.toModel(createdSetting);
     }


### PR DESCRIPTION
Bugfix that prevents the unwanted propagation of configuration settings to active modules.
Not setting the module made the module config topic message driven beans handle the request messages as if they were global configuration settings and not module specific configuration. 
This behaviour was noticed the 1ste time a new plugin was deployed on an environment. 
Note that a restart of a module would trigger the settings configuration synchronization and results in  a consistent state again.